### PR TITLE
Prepare for 0.1.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fv-template"
-version = "0.0.0"
+version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # `fv-template`
 
+[![Rust](https://github.com/sval-rs/fv-template/workflows/Rust/badge.svg)](https://github.com/sval-rs/fv-template/actions)
+[![Latest version](https://img.shields.io/crates/v/fv-template.svg)](https://crates.io/crates/fv-template)
+[![Documentation Latest](https://docs.rs/fv-template/badge.svg)](https://docs.rs/fv-template)
+
 An alternative to `format_args!` (and `log!`) for string templating. Templates take the following form:
 
 ```

--- a/src/ct.rs
+++ b/src/ct.rs
@@ -87,6 +87,11 @@ pub struct Template {
 }
 
 impl Template {
+    /**
+    Parse a template from a `TokenStream`.
+
+    The `TokenStream` is typically all the tokens given to a macro.
+    */
     pub fn parse2(input: TokenStream) -> Result<Self, Error> {
         struct Scan {
             iter: Peekable<token_stream::IntoIter>,
@@ -206,10 +211,16 @@ impl Template {
         })
     }
 
+    /**
+    Field values that appear before the template string literal.
+    */
     pub fn before_template_field_values<'a>(&'a self) -> impl Iterator<Item = &'a FieldValue> {
         self.before_template.iter()
     }
 
+    /**
+    Field values that appear within the template string literal.
+    */
     pub fn template_field_values<'a>(&'a self) -> impl Iterator<Item = &'a FieldValue> {
         self.template.iter().filter_map(|part| {
             if let Part::Hole { expr, .. } = part {
@@ -220,10 +231,16 @@ impl Template {
         })
     }
 
+    /**
+    Field values that appear after the template string literal.
+    */
     pub fn after_template_field_values<'a>(&'a self) -> impl Iterator<Item = &'a FieldValue> {
         self.after_template.iter()
     }
 
+    /**
+    Generate a `TokenStream` that constructs a runtime representation of this template.
+    */
     pub fn to_rt_tokens(&self, base: TokenStream) -> TokenStream {
         struct DefaultVisitor;
 
@@ -232,6 +249,11 @@ impl Template {
         self.to_rt_tokens_with_visitor(base, DefaultVisitor)
     }
 
+    /**
+    Generate a `TokenStream` the constructs a runtime representation of this template.
+
+    The `Visitor` has a chance to modify fragments of the template during code generation.
+    */
     pub fn to_rt_tokens_with_visitor(
         &self,
         base: TokenStream,

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -74,6 +74,9 @@ impl
         fn(&mut fmt::Formatter, &str) -> fmt::Result,
     >
 {
+    /**
+    Create a new rendering context with default handling for holes.
+    */
     pub fn new() -> Self {
         Context {
             fill: |_, _| None,
@@ -125,11 +128,26 @@ impl Default
     }
 }
 
+/**
+A fragment of a template.
+
+A set of `Part`s can be concatenated to form a user-facing representation
+of a template.
+*/
 pub enum Part<'a> {
+    /**
+    A plain text fragment.
+    */
     Text(&'a str),
+    /**
+    A hole in the template with a corresponding label to fill.
+    */
     Hole(&'a str),
 }
 
+/**
+Construct a `Template` from a set of `Part`s.
+*/
 pub fn template<'a>(parts: &'a [Part<'a>]) -> Template<'a> {
     Template { parts }
 }


### PR DESCRIPTION
This is an initial release of `fv-template` with support for parsing and rendering field-value string templates.