### PR TITLE
Make the Visitor type able to generate runtime templates

### DIFF
--- a/src/rt.rs
+++ b/src/rt.rs
@@ -7,6 +7,7 @@ use std::fmt;
 /**
 A runtime field-value template.
 */
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Template<'a>(pub &'a [Part<'a>]);
 
 impl<'a> Template<'a> {
@@ -132,6 +133,7 @@ A fragment of a template.
 A set of `Part`s can be concatenated to form a user-facing representation
 of a template.
 */
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Part<'a> {
     /**
     A plain text fragment.

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -7,9 +7,7 @@ use std::fmt;
 /**
 A runtime field-value template.
 */
-pub struct Template<'a> {
-    parts: &'a [Part<'a>],
-}
+pub struct Template<'a>(pub &'a [Part<'a>]);
 
 impl<'a> Template<'a> {
     /**
@@ -36,7 +34,7 @@ impl<'a> Template<'a> {
             TMissing: Fn(&mut fmt::Formatter, &str) -> fmt::Result,
         {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                for part in self.template.parts {
+                for part in self.template.0 {
                     match part {
                         Part::Text(text) => f.write_str(text)?,
                         Part::Hole(label) => {
@@ -145,13 +143,6 @@ pub enum Part<'a> {
     Hole(&'a str),
 }
 
-/**
-Construct a `Template` from a set of `Part`s.
-*/
-pub fn template<'a>(parts: &'a [Part<'a>]) -> Template<'a> {
-    Template { parts }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -183,7 +174,7 @@ mod tests {
         ];
 
         for (parts, ctx, expected) in cases {
-            let template = template(parts);
+            let template = Template(parts);
 
             let actual = template.render(ctx).to_string();
 


### PR DESCRIPTION
This PR refactors the `Visitor` type so that it's generic enough to construct custom runtime template types. I've also made the "default" template type fully open so that it can be generated entirely using literal syntax.